### PR TITLE
Tweaks to get GLFW building natively on AmigaOS 4 with an unmodified SDK

### DIFF
--- a/deps/getopt.c
+++ b/deps/getopt.c
@@ -36,7 +36,9 @@ const int optional_argument = 2;
 char* optarg;
 int optopt;
 /* The variable optind [...] shall be initialized to 1 by the system. */
+#ifndef NEWLIB
 int optind = 1;
+#endif
 int opterr;
 
 static char* optcursor = NULL;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,9 @@ if (APPLE)
 elseif (WIN32)
     target_sources(glfw PRIVATE win32_time.h win32_thread.h win32_module.c
                                 win32_time.c win32_thread.c)
+elseif(AMIGAOS4)
+    target_sources(glfw PRIVATE posix_time.h posix_thread.h
+                                posix_time.c posix_thread.c)
 else()
     target_sources(glfw PRIVATE posix_time.h posix_thread.h posix_module.c
                                 posix_time.c posix_thread.c)
@@ -66,7 +69,7 @@ endif()
 
 if (GLFW_BUILD_OS4)
     target_compile_definitions(glfw PRIVATE _GLFW_OS4)
-    target_sources(glfw PRIVATE os4_init.c os4_window.c os4_monitor.c os4_context.c os4_joystick.c)
+    target_sources(glfw PRIVATE os4_init.c os4_window.c os4_monitor.c os4_context.c os4_joystick.c dummy_module.c)
 endif()
 
 if (GLFW_BUILD_WAYLAND)
@@ -153,14 +156,15 @@ endif()
 
 if (GLFW_BUILD_OS4)
     if (CLIB4)
-        target_compile_options(glfw PRIVATE "-DGL4ES" "-gstabs")
+        target_compile_options(glfw PRIVATE -mcrt=clib4 -DGL4ES -gstabs)
         target_link_libraries(glfw PRIVATE "-lGL")
+	target_link_options(glfw INTERFACE -athread=native -mcrt=clib4)
     else()
         target_compile_options(glfw PRIVATE "-DGL4ES" "-gstabs" "-DNEWLIB")
-        target_link_libraries(glfw PRIVATE "-lgl4es -ldl")
+        target_link_libraries(glfw PRIVATE -lgl4es)
+	target_link_options(glfw INTERFACE -athread=native)
     endif()
 endif()
-
 if (GLFW_BUILD_COCOA)
     target_link_libraries(glfw PRIVATE "-framework Cocoa"
                                        "-framework IOKit"

--- a/src/dummy_module.c
+++ b/src/dummy_module.c
@@ -1,0 +1,48 @@
+//========================================================================
+// GLFW 3.5 Dummy Module for platforms tat don't need modules - www.glfw.org
+//------------------------------------------------------------------------
+// Copyright (c) 2021 Camilla Löwy <elmindreda@glfw.org>
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions:
+//
+// 1. The origin of this software must not be misrepresented; you must not
+//    claim that you wrote the original software. If you use this software
+//    in a product, an acknowledgment in the product documentation would
+//    be appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such, and must not
+//    be misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source
+//    distribution.
+//
+//========================================================================
+
+#include "internal.h"
+
+//////////////////////////////////////////////////////////////////////////
+//////                       GLFW platform API                      //////
+//////////////////////////////////////////////////////////////////////////
+
+void* _glfwPlatformLoadModule(const char* path)
+{
+    return NULL;
+}
+
+void _glfwPlatformFreeModule(void* module)
+{
+    ;
+}
+
+GLFWproc _glfwPlatformGetModuleSymbol(void* module, const char* name)
+{
+    return NULL;
+}
+
+

--- a/src/os4_window.c
+++ b/src/os4_window.c
@@ -926,6 +926,7 @@ void _glfwPollEventsOS4(void)
                 break;
 
             case IDCMP_RAWKEY:
+            {
                 uint8_t rawkey = msg.Code & 0x7F;
                 dprintf("RAWKEY = 0x%x\n", rawkey);
                 int key = _glfw.os4.keycodes[rawkey];
@@ -957,8 +958,10 @@ void _glfwPollEventsOS4(void)
                     _glfwInputKey(window, key, rawkey, GLFW_RELEASE, mods);                          
                 }
                 break;
+            }
 
             case IDCMP_MOUSEBUTTONS:
+            {
                 int button = OS4_GetButton(imsg->Code);
                 int state = OS4_GetButtonState(imsg->Code);
                 int bmods = OS4_TranslateState(msg.Qualifier);
@@ -968,8 +971,10 @@ void _glfwPollEventsOS4(void)
                                      state,
                                      bmods);
                 break;
+            }
 
             case IDCMP_EXTENDEDMOUSE:
+            {
                 struct IntuiWheelData *data = (struct IntuiWheelData *)msg.Gadget;
                 if (data->WheelY < 0) {
                     _glfwInputScroll(window, 0.0, 1.0);
@@ -983,7 +988,7 @@ void _glfwPollEventsOS4(void)
                     _glfwInputScroll(window, -1.0, 0.0);
                 }
                 break;
-
+            }
             case IDCMP_NEWSIZE:
                 if (window != NULL) {
                     window->os4.width = msg.Width;


### PR DESCRIPTION
These changes enable GLFW to build natively on AmigaOS 4 with an unmodified SDK.

This does the following:
- Eliminates the need for libdl (newlib only provides libdl.so)
- Fixes some compiler errors with GCC 8 in os4_window.c
- Tweaks getopt.c to avoid a duplicate symbol error with newlib